### PR TITLE
Fixed a bugs in normCast.py and normFileSend.py

### DIFF
--- a/examples/python/normCast.py
+++ b/examples/python/normCast.py
@@ -301,14 +301,16 @@ class NormCaster():
                 self.is_running = False
                 return 
         
-        obj:Optional[pynorm.Object] = session.fileEnqueue(self.pendingSendFilePath, info= self.pendingSendFilePath.replace("\\","/").encode() )
+        lastSlash = self.pendingSendFilePath.rfind('/')
+        filename = self.pendingSendFilePath[lastSlash+1:]
+        obj:Optional[pynorm.Object] = session.fileEnqueue(self.pendingSendFilePath, info= filename.encode() )
         if obj:
             if self.opts.ack:
                 session.setWatermark(obj,True)
             logging.info(f"add file:{self.pendingSendFilePath}  {obj._object}")
             self.pendingSendFilePath = None # succeed enqued
         else:
-            logging.warning(f"fileEnqueue: {sendFilePath} failure!")
+            logging.warning(f"fileEnqueue: {self.pendingSendFilePath} failure!")
 
     def handle_norm_event(self, event:pynorm.Event):
         session:pynorm.Session = event.session

--- a/examples/python/normFileSend.py
+++ b/examples/python/normFileSend.py
@@ -44,7 +44,7 @@ def main(argv):
     session.startSender(randint(0, 1000), 1024**2, 1400, 64, 16)
 
     print(('Sending file %s' % filename))
-    session.fileEnqueue(filepath, filename)
+    session.fileEnqueue(filepath, info=filename.encode())
 
     try:
         for event in instance:


### PR DESCRIPTION
I fixed a bug in normCast.py that the receiver to get the entire file path from the sender instead of just the file name. In the process, I also identified and fixed a bug in normFileSend.py that was causing a TypeError.